### PR TITLE
Update for Fedora 28

### DIFF
--- a/mrepo/fedora.conf
+++ b/mrepo/fedora.conf
@@ -1,6 +1,6 @@
 [fedora]
 name = Fedora $release ($arch)
-release = 26
+release = 28
 #iso = Fedora-Server-DVD-$arch-$release.iso
 core = rsync://mirror.math.princeton.edu/pub/fedora/linux/releases/$release/Everything/$arch/os/
 updates = rsync://mirror.math.princeton.edu/pub/fedora/linux/updates/$release/$arch/


### PR DESCRIPTION
Fedora 26 is unsupported and no longer present on the mirror server.