### PR TITLE
Correct file location dependency for zabbix agent

### DIFF
--- a/zabbix/init.sls
+++ b/zabbix/init.sls
@@ -14,7 +14,7 @@ zabbix-agent:
     - require:
       - pkg: zabbix-agent
       - file: /etc/zabbix/zabbix_agentd.conf
-      - file: /var/run/zabbix_agentd.pid
+      - file: /var/run/zabbix
 
 /etc/zabbix/zabbix_agentd.conf:
   file.managed:


### PR DESCRIPTION
When getting on-site Reggie VMs set up for MAGFest 2020, Eli noticed this bug.